### PR TITLE
Enable code analysis for all builds and fix warnings

### DIFF
--- a/inc/Common.csproj.targets
+++ b/inc/Common.csproj.targets
@@ -22,6 +22,9 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>$(IncludeDir)KeyFile.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\inc\Common.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(IncludeDir)BrandingInfo.cs">
       <Link>Properties\BrandingInfo.cs</Link>

--- a/src/PowerShell/PowerShell.csproj
+++ b/src/PowerShell/PowerShell.csproj
@@ -15,9 +15,6 @@
       CalculateVersion;
     </BeforeTransform>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <CodeAnalysisRuleSet>..\..\inc\Common.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9f4be179981a58d1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/Setup/Module.wixproj
+++ b/src/Setup/Module.wixproj
@@ -9,7 +9,7 @@
     <OutputType>package</OutputType>
     <ProjectGuid>{d2630778-0547-48d1-a8ca-e93d0d7a8b02}</ProjectGuid>
     <SetMsiAssemblyNameFileVersion>true</SetMsiAssemblyNameFileVersion>
-    <SuppressIces>ICE03;ICE38;ICE64;ICE91</SuppressIces>
+    <SuppressIces>ICE03;ICE38;ICE40;ICE61;ICE64;ICE91</SuppressIces>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Psmsi.sln))\inc\Common.props"/>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">

--- a/test/PowerShell.Test/PowerShell.Test.csproj
+++ b/test/PowerShell.Test/PowerShell.Test.csproj
@@ -10,9 +10,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <CodeAnalysisRuleSet>..\..\inc\Common.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Deployment.WindowsInstaller, Version=3.0.0.0, Culture=neutral, PublicKeyToken=9f4be179981a58d1, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Had a few warnings from the WiX project that are by design, so disabled those as well.