### PR TITLE
Publish symbols only for release builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,3 +57,5 @@ deploy:
     api_key:
       secure: WPxjuSouwbCdM6I771BfIbOk8gA883+l9RKUCfFknaUT1vYPmTpT2ABF9r+J0JgR
     artifact: /.*\.symbols\.nupkg/
+    on:
+      branch: master


### PR DESCRIPTION
Last branch build worked, so disabling symbol publishing except from master for release builds.