### PR TITLE
Update version information

### DIFF
--- a/inc/Common.props
+++ b/inc/Common.props
@@ -8,7 +8,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
-    <RestorePackages>true</RestorePackages>
+    <RestorePackages>false</RestorePackages>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/src/PowerShell/PowerShell.csproj
+++ b/src/PowerShell/PowerShell.csproj
@@ -156,9 +156,7 @@
       <Sign>True</Sign>
       <SubType>Designer</SubType>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
     <None Include="PowerShell.nuspec" />
   </ItemGroup>
   <ItemGroup>
@@ -185,9 +183,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(IncludeDir)Common.targets" />
   <Import Project="$(IncludeDir)TextTemplating.targets" />
@@ -212,22 +209,22 @@
       </T4ParameterValues>
     </ItemGroup>
   </Target>
-  <Target Name="BuildPackage" DependsOnTargets="CalculateVersion" Inputs="$(TargetPath);$(MSBuildProjectName).nuspec" Outputs="$(OutputPath)MSI.$(BuildVersionSimple).nupkg">
+  <Target Name="BuildPackage" DependsOnTargets="CalculateVersion" Inputs="$(TargetPath);$(MSBuildProjectName).nuspec" Outputs="$(OutputPath)MSI.$(NuGetPackageVersion).nupkg">
     <PropertyGroup>
       <ProjectPath>$(MSBuildProjectDirectory)\$(MSBuildProjectName).nuspec</ProjectPath>
-      <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "SolutionDir=$(SolutionDir);Configuration=$(Configuration);Platform=$(Platform);Version=$(BuildVersionSimple)" -OutputDirectory "$(OutputPath.TrimEnd('\'))" -Symbols -NonInteractive -NoPackageAnalysis</BuildCommand>
+      <BuildCommand>$(NuGetCommand) pack "$(ProjectPath)" -Properties "SolutionDir=$(SolutionDir);Configuration=$(Configuration);Platform=$(Platform);Version=$(NuGetPackageVersion)" -OutputDirectory "$(OutputPath.TrimEnd('\'))" -Symbols -NonInteractive -NoPackageAnalysis</BuildCommand>
     </PropertyGroup>
-    <Exec Command="$(BuildCommand)" Outputs="$(OutputPath)MSI.$(BuildVersionSimple).nupkg">
+    <Exec Command="$(BuildCommand)" Outputs="$(OutputPath)MSI.$(NuGetPackageVersion).nupkg">
       <Output TaskParameter="Outputs" ItemName="FileWrites" />
     </Exec>
   </Target>
   <Target Name="AfterBuild" DependsOnTargets="BuildPackage" />
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.1.5.46\build\portable-net+win+wpa+wp+sl+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.1.5.46\build\portable-net+win+wpa+wp+sl+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.1.5.46\build\portable-net+win+wpa+wp+sl+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.1.5.46\build\portable-net+win+wpa+wp+sl+netmf+MonoAndroid+MonoTouch+Xamarin.iOS\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
   <!-- vim: set sw=2 ts=2 sts=2 ft=xml: -->
 </Project>

--- a/src/PowerShell/packages.config
+++ b/src/PowerShell/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nerdbank.GitVersioning" version="1.5.46" targetFramework="net40" developmentDependency="true" />
-  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net40" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="2.2.33" targetFramework="net35" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net35" developmentDependency="true" />
 </packages>

--- a/test/PowerShell.Test/PowerShell.Test.csproj
+++ b/test/PowerShell.Test/PowerShell.Test.csproj
@@ -130,25 +130,24 @@
     <Content Include="Data\test.cub" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <AdditionalFiles Include="$(SolutionDir)inc\stylecop.json">
       <Visible>false</Visible>
     </AdditionalFiles>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.2\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(IncludeDir)Common.targets" />
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.1.5.46\build\dotnet\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.1.5.46\build\dotnet\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.1.5.46\build\dotnet\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.1.5.46\build\dotnet\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.2.2.33\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
   <!-- vim: set sw=2 ts=2 sts=2 ft=xml: -->
 </Project>

--- a/test/PowerShell.Test/packages.config
+++ b/test/PowerShell.Test/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Nerdbank.GitVersioning" version="1.5.46" targetFramework="net45" developmentDependency="true" />
-  <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net45" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="2.2.33" targetFramework="net45" developmentDependency="true" />
+  <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/version.json
+++ b/version.json
@@ -1,16 +1,12 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.2.0",
+  "version": "3.3",
   "publicReleaseRefSpec": [
     "^refs/heads/master$"
   ],
   "cloudBuild": {
     "buildNumber": {
-      "enabled": true,
-      "includeCommitId": {
-        "when": "nonPublicReleaseOnly",
-        "where": "buildMetadata"
-      }
+      "enabled": true
     },
     "setVersionVariables": true
   }


### PR DESCRIPTION
Changes the nuget version to properly use prerelease metadata, though the build number still uses semver 2 build metadata.