### PR TITLE
Add integration tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,10 +27,12 @@ jobs:
     displayName: Restore packages
 
   - powershell: |
-      $ErrorActionPreference = 'Stop'
-      $VerbosePreference = 'Continue'
       Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-      Install-Module -Name platyPS -Repository PSGallery -SkipPublisherCheck -Force
+      Install-Module -Name Pester, platyPS -Repository PSGallery -SkipPublisherCheck -Force
+    displayName: Install modules
+
+  - powershell: |
+      $VerbosePreference = 'Continue'
       New-ExternalHelp -Path "${env:BUILD_SOURCESDIRECTORY}\docs" -OutputPath "${env:BUILD_SOURCESDIRECTORY}\src\PowerShell\bin\${env:BuildConfiguration}" -Force
     displayName: Compile documentation
 
@@ -51,6 +53,21 @@ jobs:
       configuration: $(BuildConfiguration)
       platform: $(BuildPlatform)
       runInParallel: true
+
+  - template: inc\test-integration.yml
+
+  - template: inc\test-integration.yml
+    parameters:
+      Version: 2.0
+
+  - task: PublishTestResults@2
+    displayName: Publish Pester test results
+    inputs:
+      testResultsFormat: NUnit
+      testResultsFiles: |
+        Pester.*.results.xml
+      searchFolder: $(Build.ArtifactStagingDirectory)\bin\$(BuildConfiguration)
+      mergeTestResults: true
 
   - task: CopyFiles@2
     displayName: Copy files

--- a/inc/test-integration.yml
+++ b/inc/test-integration.yml
@@ -1,0 +1,27 @@
+parameters:
+  Version: latest
+
+steps:
+- powershell: |
+    $params = @(
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy', 'Bypass',
+      '-OutputFormat', 'Text'
+    )
+
+    if ($env:VERSION -ne 'latest') {
+      $params += '-Version', "${env:VERSION}"
+    }
+
+    powershell.exe $params -Command {
+      Import-Module -Name "${env:PWD}\src\PowerShell\bin\${env:CONFIGURATION}\MSI.psd1" -ErrorAction Stop
+      Invoke-Pester -Script "${env:PWD}\test\Scripts" -EnableExit -OutputFile "${env:OUTDIR}\Pester.${env:VERSION}.results.xml" -OutputFormat NUnitXml
+    }
+  displayName: Test PowerShell version ${{ parameters.Version }}
+  env:
+    CONFIGURATION: $(BuildConfiguration)
+    OUTDIR: $(Build.ArtifactStagingDirectory)\bin\$(BuildConfiguration)
+    PWD: $(System.DefaultWorkingDirectory)
+    VERSION: ${{ parameters.Version }}

--- a/test/Scripts/Module.Tests.ps1
+++ b/test/Scripts/Module.Tests.ps1
@@ -1,0 +1,41 @@
+# The MIT License (MIT)
+#
+# Copyright (c) Microsoft Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+Describe 'Module' {
+    Context 'Get-MSIProductInfo' {
+        BeforeAll {
+            $product = Get-MSIProductInfo -UserContext 'Machine' | Where-Object { -not $_.IsAdvertised } | Select-Object -First 1
+        }
+
+        It 'exists' {
+            $product | Test-Path | Should Be $True
+        }
+
+        It 'eq Get-MSIProperty "ProductCode"' {
+            $product | Get-MSIProperty 'ProductCode' | Select-Object -ExpandProperty 'Value' | Should Be $product.ProductCode
+        }
+
+        It 'is Package' {
+            $product | Get-MSIFileType | Should Be 'Package'
+        }
+    }
+}


### PR DESCRIPTION
Run integration tests for PowerShell versions 2.0 and latest installed on the machine. Depends on at least one per-machine MSI be installed, which given the vmImage is certainly likely.

Related to issue #34